### PR TITLE
Added advanced telemetry setting and build

### DIFF
--- a/apps/settings/elements/developer_hud.html
+++ b/apps/settings/elements/developer_hud.html
@@ -9,6 +9,10 @@
       <ul>
         <li>
           <label class="pack-checkbox">
+            <input type="checkbox" name="debug.performance_data.advanced_telemetry">
+            <span data-l10n-id="hud-telemetry"></span>
+          </label>
+          <label class="pack-checkbox">
             <input type="checkbox" name="debug.fps.enabled">
             <span class="color-preview fps-monitor" data-l10n-id="hud-fps"></span>
           </label>

--- a/apps/settings/locales/settings.en-US.properties
+++ b/apps/settings/locales/settings.en-US.properties
@@ -1206,6 +1206,7 @@ hud-jsother=JS Other
 hud-dom=DOM
 hud-style=Style
 hud-other=Other
+hud-telemetry=Advanced Telemetry
 software=Software
 devSettings=Developer Settings
 debug=Debug

--- a/build/config/common-settings.json
+++ b/build/config/common-settings.json
@@ -44,6 +44,7 @@
    "debug.log-animations.enabled": false,
    "debug.paint-flashing.enabled": false,
    "debug.peformancedata.shared": false,
+   "debug.performance_data.advanced_telemetry": false,
    "debug.gaia.enabled": false,
    "deviceinfo.build_number": "",
    "deviceinfo.firmware_revision": "",

--- a/build/settings.js
+++ b/build/settings.js
@@ -282,6 +282,28 @@ function execute(config) {
     settings['devtools.qps.enabled'] = true;
   }
 
+  if (config.DOGFOOD === '1') {
+    settings['devtools.overlay'] = true;
+    settings['debug.performance_data.advanced_telemetry'] = true;
+    settings['debug.ttl.enabled'] = true;
+    settings['debug.fps.enabled'] = false;
+    settings['hud.logging'] = false;
+    settings['devtools.overlay.system'] = false;
+    settings['hud.errors'] = false;
+    settings['hud.warnings'] = false;
+    settings['hud.security'] = false;
+    settings['hud.reflows'] = true;
+    settings['hud.jank'] = true;
+    settings['hud.uss'] = false;
+    settings['hud.appmemory'] = false;
+    settings['hud.jsobjects'] = false;
+    settings['hud.jsstrings'] = false;
+    settings['hud.jsother'] = false;
+    settings['hud.dom'] = false;
+    settings['hud.style'] = false;
+    settings['hud.other'] = false;
+  }
+
   settings['language.current'] = config.GAIA_DEFAULT_LOCALE;
 
   if (config.DEVICE_DEBUG === '1') {


### PR DESCRIPTION
I found the setting needed to exist in order to have a settings observer for the setting so I added the advanced telemetry setting to the Developer HUD settings panel. I am updated my hud.js to use the new setting. This all works: when the setting is enabled, hud.js sends the advanced telemetry events; when the setting is not enabled, no advanced telemetry events are set.

Also, I added an ADVANCED_TELEMETRY build but when I use it is not setting the "at" setting, so it seems I'm missing something.
